### PR TITLE
feat: add main branch head commit sha to deployment payload

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   environment_url:
     required: false
     description: link for the deployment (e.g. http://staging.your.app/status)
+  main_branch:
+    required: false
+    description: name of main branch of the repo, to get and store sha of the head commit and track diff being deployed
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-deploy",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "private": true,
   "description": "Action to manage GitHub deployments",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ export async function run (): Promise<void> {
   let environment: string
   let environmentUrl: string
   let deploymentId: string
+  let mainBranch: string
 
   const { actor, ref } = github.context
 
@@ -59,6 +60,9 @@ export async function run (): Promise<void> {
     environmentUrl = getInput('environment_url') ?? ''
     console.log(`environmentUrl: ${environmentUrl}`)
 
+    mainBranch = getInput('main_branch') ?? 'master'
+    console.log(`main branch: ${mainBranch}`)
+
     const shouldRequireDeploymentId = type === 'finish' || type === 'delete'
     deploymentId = getInput('deployment_id', { required: shouldRequireDeploymentId }) ?? '0'
     console.log(`deploymentId: ${deploymentId}`)
@@ -82,7 +86,8 @@ export async function run (): Promise<void> {
           description,
           status,
           environment,
-          environmentUrl
+          environmentUrl,
+          mainBranch
         )
         console.log(`setOutput::deployment_id: ${deploymentId}`)
         core.setOutput('deployment_id', deploymentId)

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -8,6 +8,7 @@ import nock from 'nock'
 nock.disableNetConnect()
 
 const listDeploymentsReply = [] as any
+const getBranchReply = { commit: { sha: "fake-sha" } } as any
 const postDeploymentReply = { id: 42 } as any
 const postStatusReply = {} as any
 
@@ -40,6 +41,10 @@ describe('create', () => {
       .get('/repos/owner/repo/deployments?ref=refs%2Fheads%2Fmaster&environment=master')
       .reply(200, listDeploymentsReply)
 
+    const getMainBranchSha = nock('https://api.github.com')
+      .get('/repos/owner/repo/branches/master')
+      .reply(200, getBranchReply)
+
     const postDeployment = nock('https://api.github.com')
       .post('/repos/owner/repo/deployments')
       .reply(200, postDeploymentReply)
@@ -53,6 +58,7 @@ describe('create', () => {
 
     // assert
     getListDeployments.done()
+    getMainBranchSha.done()
     postDeployment.done()
     postStatus.done()
   })
@@ -73,6 +79,10 @@ describe('create', () => {
       .get('/repos/owner/repo/deployments?ref=refs%2Fheads%2Fmaster&environment=master')
       .reply(200, listDeploymentsReply)
 
+    const getMainBranchSha = nock('https://api.github.com')
+      .get('/repos/owner/repo/branches/master')
+      .reply(200, getBranchReply)
+
     const postDeployment = nock('https://api.github.com')
       .post('/repos/owner/repo/deployments')
       .reply(400, {"resource":"DeploymentStatus","code":"custom","field":"environment_url","message":"environment_url must use http(s) scheme"})
@@ -88,6 +98,7 @@ describe('create', () => {
     // assert
     getListDeployments.done()
     postDeployment.done()
+    getMainBranchSha.done()
     expect(setFailedSpy.mock.calls).toHaveLength(1)
   })
 })


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
> we want to track main branch sha during the deployment to see custom branches being deployed

this will allow us to use less permissive token during dashboard generation.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
Related to github/npm#531