### PR TITLE
feat: add diff to slack message and make wording more clear and consise

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: create a deployment
-      uses: npm/action-deploy@v2.1.0
+      uses: npm/action-deploy@v2.1.1
       id: create-deployment
       with:
         type: create
@@ -20,7 +20,7 @@ jobs:
         environment_url: https://npmjs.com
         job_status: ${{job.status}}
         slack_token: ${{secrets.NPM_ROBOT_SLACK_TOKEN}}
-        slack_channel: npm-ops
+        slack_channel: npm-test-notifications
 
     # add here an actual deployment
     - name: placeholder for actual deployment

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -12100,10 +12100,11 @@ function postSlackNotification(slackToken, slackChannel, environment, status, co
             if (payload !== null && typeof payload.compare === 'string') {
                 const beforeSha = ((_a = payload.before) !== null && _a !== void 0 ? _a : '').slice(0, 7);
                 const afterShaMessage = ((_b = payload.head_commit) !== null && _b !== void 0 ? _b : {}).message;
-                commitText = `diff <${beforeSha} ⇢ 🚀${afterSha}🚀|${payload.compare}> \`${afterShaMessage}\``;
+                commitText = `diff <${payload.compare}|${beforeSha} ⇢ 🚀${afterSha}🚀> \`${afterShaMessage}\``;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-            const text = `<${repoUrl}|${repo.repo}> deployment completed to environment <${deploymentUrl}|${environment}> with status \`${status}\` and ${commitText} by @${actor}`;
+            const statusIcon = status === 'success' ? '✅' : '❌';
+            const text = `<${repoUrl}|${repo.repo}> deployment completed to <${deploymentUrl}|${environment}> environment with ${status}${statusIcon} and ${commitText} by @${actor}`;
             const slackClient = new web_api_1.WebClient(slackToken);
             const slackParams = {
                 channel: slackChannel,

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -12085,26 +12085,27 @@ function getEnvironment(ref) {
 }
 exports.getEnvironment = getEnvironment;
 function postSlackNotification(slackToken, slackChannel, environment, status, context) {
-    var _a, _b;
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         if (slackToken === '' || slackChannel === '') {
             return;
         }
         const { actor, repo, sha, payload } = context;
         try {
+            const statusIcon = status === 'success' ? '✅' : '❌';
             const afterSha = sha.slice(0, 7);
             const repoUrl = `https://github.com/${repo.owner}/${repo.repo}`;
             const deploymentUrl = `${repoUrl}/deployments?environment=${environment}#activity-log`;
             const commitUrl = `${repoUrl}/commit/${sha}`;
-            let commitText = `commit <${commitUrl}|${afterSha}>`;
-            if (payload !== null && typeof payload.compare === 'string') {
-                const beforeSha = ((_a = payload.before) !== null && _a !== void 0 ? _a : '').slice(0, 7);
-                const afterShaMessage = ((_b = payload.head_commit) !== null && _b !== void 0 ? _b : {}).message;
-                commitText = `diff <${payload.compare}|${beforeSha} ⇢ 🚀${afterSha}🚀> \`${afterShaMessage}\``;
+            let commitText = `<${commitUrl}|${afterSha}>`;
+            const payloadForPushes = payload;
+            if ((payloadForPushes === null || payloadForPushes === void 0 ? void 0 : payloadForPushes.compare) !== undefined) {
+                const beforeSha = payloadForPushes.before.slice(0, 7);
+                const afterShaMessage = (_a = payloadForPushes.head_commit.message) !== null && _a !== void 0 ? _a : '';
+                commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${afterShaMessage}>`;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-            const statusIcon = status === 'success' ? '✅' : '❌';
-            const text = `<${repoUrl}|${repo.repo}> deployment completed to <${deploymentUrl}|${environment}> environment with ${status}${statusIcon} and ${commitText} by @${actor}`;
+            const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> completed with ${status} ${statusIcon} by @${actor} - ${commitText}`;
             const slackClient = new web_api_1.WebClient(slackToken);
             const slackParams = {
                 channel: slackChannel,

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -12105,7 +12105,7 @@ function postSlackNotification(slackToken, slackChannel, environment, status, co
                 commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${afterShaMessage}>`;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-            const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> completed with ${status} ${statusIcon} by @${actor} - ${commitText}`;
+            const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> by @${actor} completed with ${status} ${statusIcon} - ${commitText}`;
             const slackClient = new web_api_1.WebClient(slackToken);
             const slackParams = {
                 channel: slackChannel,

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -12084,17 +12084,24 @@ function getEnvironment(ref) {
     return environment;
 }
 exports.getEnvironment = getEnvironment;
-function postSlackNotification(slackToken, slackChannel, repo, sha, environment, status, actor) {
+function postSlackNotification(slackToken, slackChannel, environment, status, context) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         if (slackToken === '' || slackChannel === '') {
             return;
         }
+        const { actor, repo, sha, payload } = context;
         try {
             const repoUrl = `https://github.com/${repo.owner}/${repo.repo}`;
             const deploymentUrl = `${repoUrl}/deployments?environment=${environment}#activity-log`;
             const commitUrl = `${repoUrl}/commit/${sha}`;
+            let commitText = `commit <${commitUrl}|${sha.slice(0, 7)}>`;
+            if (payload !== null && typeof payload.compare === 'string') {
+                const shortDiff = ((_a = payload.compare) !== null && _a !== void 0 ? _a : '').replace(/^.*\//, '');
+                commitText = `diff <${shortDiff}|${payload.compare}>`;
+            }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-            const text = `Deployment of commit <${commitUrl}|${sha.slice(0, 6)}> for <${repoUrl}|${repo.repo}> completed with status \`${status}\` to environment <${deploymentUrl}|${environment}> by @${actor}`;
+            const text = `<${repoUrl}|${repo.repo}> deployment completed to environment <${deploymentUrl}|${environment}> with status \`${status}\` and ${commitText} by @${actor}`;
             const slackClient = new web_api_1.WebClient(slackToken);
             const slackParams = {
                 channel: slackChannel,

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -12085,20 +12085,22 @@ function getEnvironment(ref) {
 }
 exports.getEnvironment = getEnvironment;
 function postSlackNotification(slackToken, slackChannel, environment, status, context) {
-    var _a;
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         if (slackToken === '' || slackChannel === '') {
             return;
         }
         const { actor, repo, sha, payload } = context;
         try {
+            const afterSha = sha.slice(0, 7);
             const repoUrl = `https://github.com/${repo.owner}/${repo.repo}`;
             const deploymentUrl = `${repoUrl}/deployments?environment=${environment}#activity-log`;
             const commitUrl = `${repoUrl}/commit/${sha}`;
-            let commitText = `commit <${commitUrl}|${sha.slice(0, 7)}>`;
+            let commitText = `commit <${commitUrl}|${afterSha}>`;
             if (payload !== null && typeof payload.compare === 'string') {
-                const shortDiff = ((_a = payload.compare) !== null && _a !== void 0 ? _a : '').replace(/^.*\//, '');
-                commitText = `diff <${shortDiff}|${payload.compare}>`;
+                const beforeSha = ((_a = payload.before) !== null && _a !== void 0 ? _a : '').slice(0, 7);
+                const afterShaMessage = ((_b = payload.head_commit) !== null && _b !== void 0 ? _b : {}).message;
+                commitText = `diff <${beforeSha} ⇢ 🚀${afterSha}🚀|${payload.compare}> \`${afterShaMessage}\``;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
             const text = `<${repoUrl}|${repo.repo}> deployment completed to environment <${deploymentUrl}|${environment}> with status \`${status}\` and ${commitText} by @${actor}`;

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -12429,7 +12429,8 @@ function post() {
         console.log(`ref: ${ref}`);
         console.log(`owner: ${repo.owner}`);
         console.log(`repo: ${repo.repo}`);
-        console.log(`sha: ${sha}`);
+        console.log(`payload: ${JSON.stringify(github.context.payload)}`);
+        console.log(`new_sha: ${sha}`);
         console.log('\n');
         try {
             console.log('### post.inputs ###');

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -11967,10 +11967,11 @@ function postSlackNotification(slackToken, slackChannel, environment, status, co
             if (payload !== null && typeof payload.compare === 'string') {
                 const beforeSha = ((_a = payload.before) !== null && _a !== void 0 ? _a : '').slice(0, 7);
                 const afterShaMessage = ((_b = payload.head_commit) !== null && _b !== void 0 ? _b : {}).message;
-                commitText = `diff <${beforeSha} ⇢ 🚀${afterSha}🚀|${payload.compare}> \`${afterShaMessage}\``;
+                commitText = `diff <${payload.compare}|${beforeSha} ⇢ 🚀${afterSha}🚀> \`${afterShaMessage}\``;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-            const text = `<${repoUrl}|${repo.repo}> deployment completed to environment <${deploymentUrl}|${environment}> with status \`${status}\` and ${commitText} by @${actor}`;
+            const statusIcon = status === 'success' ? '✅' : '❌';
+            const text = `<${repoUrl}|${repo.repo}> deployment completed to <${deploymentUrl}|${environment}> environment with ${status}${statusIcon} and ${commitText} by @${actor}`;
             const slackClient = new web_api_1.WebClient(slackToken);
             const slackParams = {
                 channel: slackChannel,

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -11951,17 +11951,24 @@ function getEnvironment(ref) {
     return environment;
 }
 exports.getEnvironment = getEnvironment;
-function postSlackNotification(slackToken, slackChannel, repo, sha, environment, status, actor) {
+function postSlackNotification(slackToken, slackChannel, environment, status, context) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         if (slackToken === '' || slackChannel === '') {
             return;
         }
+        const { actor, repo, sha, payload } = context;
         try {
             const repoUrl = `https://github.com/${repo.owner}/${repo.repo}`;
             const deploymentUrl = `${repoUrl}/deployments?environment=${environment}#activity-log`;
             const commitUrl = `${repoUrl}/commit/${sha}`;
+            let commitText = `commit <${commitUrl}|${sha.slice(0, 7)}>`;
+            if (payload !== null && typeof payload.compare === 'string') {
+                const shortDiff = ((_a = payload.compare) !== null && _a !== void 0 ? _a : '').replace(/^.*\//, '');
+                commitText = `diff <${shortDiff}|${payload.compare}>`;
+            }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-            const text = `Deployment of commit <${commitUrl}|${sha.slice(0, 6)}> for <${repoUrl}|${repo.repo}> completed with status \`${status}\` to environment <${deploymentUrl}|${environment}> by @${actor}`;
+            const text = `<${repoUrl}|${repo.repo}> deployment completed to environment <${deploymentUrl}|${environment}> with status \`${status}\` and ${commitText} by @${actor}`;
             const slackClient = new web_api_1.WebClient(slackToken);
             const slackParams = {
                 channel: slackChannel,
@@ -12429,7 +12436,7 @@ function post() {
         console.log(`ref: ${ref}`);
         console.log(`owner: ${repo.owner}`);
         console.log(`repo: ${repo.repo}`);
-        console.log(`payload: ${JSON.stringify(github.context.payload)}`);
+        console.log(`compare: ${github.context.payload.compare}`);
         console.log(`new_sha: ${sha}`);
         console.log('\n');
         try {
@@ -12464,7 +12471,7 @@ function post() {
                     return;
                 }
                 // Post Slack notification
-                yield utils_1.postSlackNotification(slackToken, slackChannel, repo, sha, environment, status, actor);
+                yield utils_1.postSlackNotification(slackToken, slackChannel, environment, status, github.context);
                 try {
                     yield complete_1.complete(client, Number(deploymentId), status);
                 }

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -11952,20 +11952,22 @@ function getEnvironment(ref) {
 }
 exports.getEnvironment = getEnvironment;
 function postSlackNotification(slackToken, slackChannel, environment, status, context) {
-    var _a;
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         if (slackToken === '' || slackChannel === '') {
             return;
         }
         const { actor, repo, sha, payload } = context;
         try {
+            const afterSha = sha.slice(0, 7);
             const repoUrl = `https://github.com/${repo.owner}/${repo.repo}`;
             const deploymentUrl = `${repoUrl}/deployments?environment=${environment}#activity-log`;
             const commitUrl = `${repoUrl}/commit/${sha}`;
-            let commitText = `commit <${commitUrl}|${sha.slice(0, 7)}>`;
+            let commitText = `commit <${commitUrl}|${afterSha}>`;
             if (payload !== null && typeof payload.compare === 'string') {
-                const shortDiff = ((_a = payload.compare) !== null && _a !== void 0 ? _a : '').replace(/^.*\//, '');
-                commitText = `diff <${shortDiff}|${payload.compare}>`;
+                const beforeSha = ((_a = payload.before) !== null && _a !== void 0 ? _a : '').slice(0, 7);
+                const afterShaMessage = ((_b = payload.head_commit) !== null && _b !== void 0 ? _b : {}).message;
+                commitText = `diff <${beforeSha} ⇢ 🚀${afterSha}🚀|${payload.compare}> \`${afterShaMessage}\``;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
             const text = `<${repoUrl}|${repo.repo}> deployment completed to environment <${deploymentUrl}|${environment}> with status \`${status}\` and ${commitText} by @${actor}`;

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -11972,7 +11972,7 @@ function postSlackNotification(slackToken, slackChannel, environment, status, co
                 commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${afterShaMessage}>`;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-            const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> completed with ${status} ${statusIcon} by @${actor} - ${commitText}`;
+            const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> by @${actor} completed with ${status} ${statusIcon} - ${commitText}`;
             const slackClient = new web_api_1.WebClient(slackToken);
             const slackParams = {
                 channel: slackChannel,

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -11952,26 +11952,27 @@ function getEnvironment(ref) {
 }
 exports.getEnvironment = getEnvironment;
 function postSlackNotification(slackToken, slackChannel, environment, status, context) {
-    var _a, _b;
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         if (slackToken === '' || slackChannel === '') {
             return;
         }
         const { actor, repo, sha, payload } = context;
         try {
+            const statusIcon = status === 'success' ? '✅' : '❌';
             const afterSha = sha.slice(0, 7);
             const repoUrl = `https://github.com/${repo.owner}/${repo.repo}`;
             const deploymentUrl = `${repoUrl}/deployments?environment=${environment}#activity-log`;
             const commitUrl = `${repoUrl}/commit/${sha}`;
-            let commitText = `commit <${commitUrl}|${afterSha}>`;
-            if (payload !== null && typeof payload.compare === 'string') {
-                const beforeSha = ((_a = payload.before) !== null && _a !== void 0 ? _a : '').slice(0, 7);
-                const afterShaMessage = ((_b = payload.head_commit) !== null && _b !== void 0 ? _b : {}).message;
-                commitText = `diff <${payload.compare}|${beforeSha} ⇢ 🚀${afterSha}🚀> \`${afterShaMessage}\``;
+            let commitText = `<${commitUrl}|${afterSha}>`;
+            const payloadForPushes = payload;
+            if ((payloadForPushes === null || payloadForPushes === void 0 ? void 0 : payloadForPushes.compare) !== undefined) {
+                const beforeSha = payloadForPushes.before.slice(0, 7);
+                const afterShaMessage = (_a = payloadForPushes.head_commit.message) !== null && _a !== void 0 ? _a : '';
+                commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${afterShaMessage}>`;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-            const statusIcon = status === 'success' ? '✅' : '❌';
-            const text = `<${repoUrl}|${repo.repo}> deployment completed to <${deploymentUrl}|${environment}> environment with ${status}${statusIcon} and ${commitText} by @${actor}`;
+            const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> completed with ${status} ${statusIcon} by @${actor} - ${commitText}`;
             const slackClient = new web_api_1.WebClient(slackToken);
             const slackParams = {
                 channel: slackChannel,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-deploy",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "description": "Action to manage GitHub deployments",
   "main": "lib/main.js",

--- a/src/post.ts
+++ b/src/post.ts
@@ -19,7 +19,8 @@ export async function post (): Promise<void> {
   console.log(`ref: ${ref}`)
   console.log(`owner: ${repo.owner}`)
   console.log(`repo: ${repo.repo}`)
-  console.log(`sha: ${sha}`)
+  console.log(`payload: ${JSON.stringify(github.context.payload)}`)
+  console.log(`new_sha: ${sha}`)
   console.log('\n')
 
   try {

--- a/src/post.ts
+++ b/src/post.ts
@@ -19,7 +19,7 @@ export async function post (): Promise<void> {
   console.log(`ref: ${ref}`)
   console.log(`owner: ${repo.owner}`)
   console.log(`repo: ${repo.repo}`)
-  console.log(`payload: ${JSON.stringify(github.context.payload)}`)
+  console.log(`compare: ${github.context.payload.compare as string}`)
   console.log(`new_sha: ${sha}`)
   console.log('\n')
 
@@ -62,7 +62,7 @@ export async function post (): Promise<void> {
       }
 
       // Post Slack notification
-      await postSlackNotification(slackToken, slackChannel, repo, sha, environment, status, actor)
+      await postSlackNotification(slackToken, slackChannel, environment, status, github.context)
 
       try {
         await complete(client, Number(deploymentId), status)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,7 @@ export async function postSlackNotification (
   slackToken: string,
   slackChannel: string,
   environment: string,
-  status: string,
+  status: DeploymentStatus,
   context: Context): Promise<void> {
   if (slackToken === '' || slackChannel === '') {
     return
@@ -52,11 +52,12 @@ export async function postSlackNotification (
     if (payload !== null && typeof payload.compare === 'string') {
       const beforeSha = (payload.before as string ?? '').slice(0, 7)
       const afterShaMessage = (payload.head_commit as {[key: string]: any} ?? {}).message as string
-      commitText = `diff <${beforeSha} ⇢ 🚀${afterSha}🚀|${payload.compare}> \`${afterShaMessage}\``
+      commitText = `diff <${payload.compare}|${beforeSha} ⇢ 🚀${afterSha}🚀> \`${afterShaMessage}\``
     }
 
     // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-    const text = `<${repoUrl}|${repo.repo}> deployment completed to environment <${deploymentUrl}|${environment}> with status \`${status}\` and ${commitText} by @${actor}`
+    const statusIcon = status === 'success' ? '✅' : '❌'
+    const text = `<${repoUrl}|${repo.repo}> deployment completed to <${deploymentUrl}|${environment}> environment with ${status}${statusIcon} and ${commitText} by @${actor}`
     const slackClient = new WebClient(slackToken)
     const slackParams: ChatPostMessageArguments = {
       channel: slackChannel,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,13 +44,15 @@ export async function postSlackNotification (
   const { actor, repo, sha, payload } = context
 
   try {
+    const afterSha = sha.slice(0, 7)
     const repoUrl = `https://github.com/${repo.owner}/${repo.repo}`
     const deploymentUrl = `${repoUrl}/deployments?environment=${environment}#activity-log`
     const commitUrl = `${repoUrl}/commit/${sha}`
-    let commitText = `commit <${commitUrl}|${sha.slice(0, 7)}>`
+    let commitText = `commit <${commitUrl}|${afterSha}>`
     if (payload !== null && typeof payload.compare === 'string') {
-      const shortDiff = (payload.compare ?? '').replace(/^.*\//, '')
-      commitText = `diff <${shortDiff}|${payload.compare}>`
+      const beforeSha = (payload.before as string ?? '').slice(0, 7)
+      const afterShaMessage = (payload.head_commit as {[key: string]: any} ?? {}).message as string
+      commitText = `diff <${beforeSha} ⇢ 🚀${afterSha}🚀|${payload.compare}> \`${afterShaMessage}\``
     }
 
     // message formatting reference - https://api.slack.com/reference/surfaces/formatting

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,7 +68,7 @@ export async function postSlackNotification (
     }
 
     // message formatting reference - https://api.slack.com/reference/surfaces/formatting
-    const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> completed with ${status} ${statusIcon} by @${actor} - ${commitText}`
+    const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> by @${actor} completed with ${status} ${statusIcon} - ${commitText}`
     const slackClient = new WebClient(slackToken)
     const slackParams: ChatPostMessageArguments = {
       channel: slackChannel,


### PR DESCRIPTION
As per discussion, we want to see the diff of what was deployed.

[Example message](https://github.slack.com/archives/C019LH97KJ9/p1598635429000500)
<img width="733" alt="Screen Shot 2020-08-28 at 20 33 09" src="https://user-images.githubusercontent.com/8243681/91597247-b70cd500-e96d-11ea-8f78-fcd50201c706.png">
