### PR TITLE
fix: multiline and long commit message break formatting

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -12102,7 +12102,8 @@ function postSlackNotification(slackToken, slackChannel, environment, status, co
             if ((payloadForPushes === null || payloadForPushes === void 0 ? void 0 : payloadForPushes.compare) !== undefined) {
                 const beforeSha = payloadForPushes.before.slice(0, 7);
                 const afterShaMessage = (_a = payloadForPushes.head_commit.message) !== null && _a !== void 0 ? _a : '';
-                commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${afterShaMessage}>`;
+                const shortShaMessage = trimEllipsis(afterShaMessage.replace(/(\r\n|\n|\r).*$/gm, ''), 60); // keep only some first symbols of the first line
+                commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${shortShaMessage}>`;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
             const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> by @${actor} completed with ${status} ${statusIcon} - ${commitText}`;
@@ -12124,6 +12125,9 @@ function postSlackNotification(slackToken, slackChannel, environment, status, co
     });
 }
 exports.postSlackNotification = postSlackNotification;
+function trimEllipsis(str, length) {
+    return str.length > length ? `${str.substring(0, length)}...` : str;
+}
 
 
 /***/ }),

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -11969,7 +11969,8 @@ function postSlackNotification(slackToken, slackChannel, environment, status, co
             if ((payloadForPushes === null || payloadForPushes === void 0 ? void 0 : payloadForPushes.compare) !== undefined) {
                 const beforeSha = payloadForPushes.before.slice(0, 7);
                 const afterShaMessage = (_a = payloadForPushes.head_commit.message) !== null && _a !== void 0 ? _a : '';
-                commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${afterShaMessage}>`;
+                const shortShaMessage = trimEllipsis(afterShaMessage.replace(/(\r\n|\n|\r).*$/gm, ''), 60); // keep only some first symbols of the first line
+                commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${shortShaMessage}>`;
             }
             // message formatting reference - https://api.slack.com/reference/surfaces/formatting
             const text = `<${repoUrl}|${repo.repo}> deployment 🚀 to <${deploymentUrl}|${environment}> by @${actor} completed with ${status} ${statusIcon} - ${commitText}`;
@@ -11991,6 +11992,9 @@ function postSlackNotification(slackToken, slackChannel, environment, status, co
     });
 }
 exports.postSlackNotification = postSlackNotification;
+function trimEllipsis(str, length) {
+    return str.length > length ? `${str.substring(0, length)}...` : str;
+}
 
 
 /***/ }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "action-deploy",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-deploy",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "Action to manage GitHub deployments",
   "main": "lib/main.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,7 +64,8 @@ export async function postSlackNotification (
     if (payloadForPushes?.compare !== undefined) {
       const beforeSha = payloadForPushes.before.slice(0, 7)
       const afterShaMessage = payloadForPushes.head_commit.message ?? ''
-      commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${afterShaMessage}>`
+      const shortShaMessage = trimEllipsis(afterShaMessage.replace(/(\r\n|\n|\r).*$/gm, ''), 60) // keep only some first symbols of the first line
+      commitText = `<${payloadForPushes.compare}|${beforeSha} ⇢ ${afterSha} ${shortShaMessage}>`
     }
 
     // message formatting reference - https://api.slack.com/reference/surfaces/formatting
@@ -83,4 +84,8 @@ export async function postSlackNotification (
   } catch (error) {
     core.error(error)
   }
+}
+
+function trimEllipsis (str: string, length: number): string {
+  return str.length > length ? `${str.substring(0, length)}...` : str
 }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Context: https://github.slack.com/archives/C016R13H5FV/p1598879831070700

![Screen Shot 2020-08-31 at 18 59 10](https://user-images.githubusercontent.com/8243681/91741164-fc731180-ebbc-11ea-802e-8005b6a1ee66.png)

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
