### PR TITLE
[Version bump] axios@1.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-deploy",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "action-deploy",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "1.11.1",
         "@actions/github": "^6.0.0",
-        "@slack/web-api": "^7.9.3"
+        "@slack/web-api": "^7.10.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -1741,18 +1741,18 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "7.9.3",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.9.3.tgz",
-      "integrity": "sha512-xjnoldVJyoUe61Ltqjr2UVYBolcsTpp5ottqzSI3l41UCaJgHSHIOpGuYps+nhLFvDfGGpDGUeQ7BWiq3+ypqA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.10.0.tgz",
+      "integrity": "sha512-kT+07JvOqpYH3b/ttVo3iqKIFiHV2NKmD6QUc/F7HrjCgSdSA10zxqi0euXEF2prB49OU7SfjadzQ0WhNc7tiw==",
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.0",
         "@slack/types": "^2.9.0",
         "@types/node": ">=18.0.0",
         "@types/retry": "0.12.0",
-        "axios": "^1.8.3",
+        "axios": "^1.11.0",
         "eventemitter3": "^5.0.1",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "is-electron": "2.2.2",
         "is-stream": "^2",
         "p-queue": "^6",
@@ -2560,9 +2560,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-deploy",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "description": "Action to manage GitHub deployments",
   "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "^6.0.0",
-    "@slack/web-api": "^7.9.3"
+    "@slack/web-api": "^7.10.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
Bump `axios` version from `1.11.0` to `1.12.2`
Bump `@slack/web-api` from `7.9.3` to `7.10.0`

### References
https://github.com/github/npm/issues/14252
