### PR TITLE
[version bump] handlebars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      contents: read
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ jobs:
         npm run all
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - uses: ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -4548,9 +4548,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- **Version bump:** Updates the `handlebars` transitive dependency from `4.7.8` to `4.7.9` to resolve a batch of critical security advisories.
- **CI fix:** Grants `deployments: write` permission to the `test` and `deploy` jobs so the action's `delete-all` / `create` steps can manage deployment statuses.

## Why the CI fix is needed

The `build-test` run on this branch failed at the **Delete all deployments** step with:

```
HttpError: Resource not accessible by integration (403)
Delete all deployments failed
POST /repos/npm/action-deploy/deployments/:id/statuses
```

The job's `GITHUB_TOKEN` was running with the default read-only permission set:

```
Contents: read
Metadata: read
Packages: read
```

Invalidating a deployment requires `POST .../deployments/:id/statuses`, which needs `deployments: write`. Adding an explicit `permissions` block restores the required scope. This PR is not cross-repository, so the elevated token permission applies.

## Changes

| File | Change |
| - | - |
| `.github/workflows/test.yml` | Add `permissions: deployments: write / contents: read` to the `test` job |
| `.github/workflows/deploy.yml` | Add `permissions: deployments: write / contents: read` to the `deploy` job |
| `package-lock.json` | Bump `handlebars` 4.7.8 → 4.7.9 |